### PR TITLE
feat: add thinking timer and token rate

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ import logging
 import streamlit as st
 import requests
 from openai import OpenAI
+import threading
+import time
 
 client = OpenAI(
     base_url="http://localhost:11434/v1",  # Ollama's default API endpoint
@@ -35,7 +37,7 @@ def get_ollama_response(prompt):
     logger.info(f"ollama_generate_ok: {response.choices[0]}")
 
     print(response.choices[0].message.content)
-    return response.choices[0].message.content
+    return response
 
 
 def main():
@@ -50,9 +52,37 @@ def main():
     question = st.text_input("What is your question?", placeholder="What is the capital of France?")
     if question:
         st.info(f"Question: {question}")
+        placeholder = st.empty()
+        timer_placeholder = st.empty()
+        response_container = {}
+
+        def fetch_response():
+            response_container['response'] = get_ollama_response(question)
+
+        thread = threading.Thread(target=fetch_response)
+        start_time = time.time()
+        thread.start()
+        while thread.is_alive():
+            elapsed = time.time() - start_time
+            timer_placeholder.info(f"Thinking... {elapsed:.1f}s")
+            time.sleep(0.1)
+        thread.join()
+        total_time = time.time() - start_time
+        timer_placeholder.info(f"Thought for {total_time:.1f}s")
+
         try:
-            response = get_ollama_response(question)
-            st.success(f"AI says: {response}")
+            response = response_container.get('response')
+            if response:
+                content = response.choices[0].message.content
+                placeholder.success(f"AI says: {content}")
+                tokens = getattr(response.usage, 'total_tokens', None)
+                if tokens is not None:
+                    token_rate = tokens / total_time if total_time > 0 else float('inf')
+                    st.caption(f"Time: {total_time:.2f}s | Token rate: {token_rate:.2f} tokens/s")
+                else:
+                    st.caption(f"Time: {total_time:.2f}s")
+            else:
+                st.error("No response received from the model.")
         except Exception as e:
             logger.error(f"ollama_error: {e}")
             st.error("Could not get a response from Ollama. Ensure the Ollama server is running and the model is available.")


### PR DESCRIPTION
## Summary
- show a real-time "Thinking" timer while awaiting model output
- display total thinking time and token rate after response

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a200ed0b7083329275c12bdac93672